### PR TITLE
Small tweaks

### DIFF
--- a/MGSHDFix.ini
+++ b/MGSHDFix.ini
@@ -80,3 +80,12 @@ Enabled = false
 ; Converts FOV to vert- and matches 16:9 horizontal FOV.
 ; Only applies at <16:9. Will be disabled if aspect ratio is >1.778~.
 Enabled = true
+
+[Vector Line Fix]
+; Fixes scaling for vector/line based effects in 2 & 3, such as rain, lasers, bullet trails, ect
+; which weren't properly scaled up from their PS2 resolutions.
+; Generally want to keep this to false. 
+Disable = false
+; Scaling Size: Lower numbers increase the width of vector effects at 1/scale (ie 1/512, or 0.001953125)
+; 512 makes line widths identical in scale to PCSX2's corrected line widths.
+Line Scale = 512


### PR DESCRIPTION
Small cleanup here and there.

I added iVectorLineScale, which preferable should be utilized as `float thicknessFraction = 1.0f / iVectorLineScale;`, however I'm not familiar with how to concatenate raw strings. Would you be able to implement that by chance? 

If not, feel free to just remove all the references to iVectorLineScale, & the Line Scale config entry, 512 is 1:1 accurate to PCSX2 anyway so I'm MORE than happy with this as is. :D

Thank you SO so much again!